### PR TITLE
Switching to c++_static as stlport_static was removed from NDK r18b.

### DIFF
--- a/lib/src/main/jni/Application.mk
+++ b/lib/src/main/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_STL := stlport_static
+APP_STL := c++_static
 APP_OPTIM := release
 APP_ABI := armeabi-v7a,arm64-v8a,x86,x86_64
 APP_PLATFORM := android-15


### PR DESCRIPTION
See: [Android NDK, Revision r18b (September 2018)](https://developer.android.com/ndk/downloads/revision_history).